### PR TITLE
fix: use sized 1 channel

### DIFF
--- a/tm2/pkg/bft/consensus/common_test.go
+++ b/tm2/pkg/bft/consensus/common_test.go
@@ -255,7 +255,12 @@ func subscribeToVoter(cs *ConsensusState, addr crypto.Address) <-chan events.Eve
 		return false
 	})
 
-	testch := make(chan events.Event, 16)
+	// This modification addresses the deadlock issue outlined in issue
+	// #1320. By creating a buffered channel, we ensure that events are
+	// consumed even if the main thread is blocked. This prevents the
+	// deadlock that occurred when eventSwitch.FireEvent was blocked due to
+	// no available consumers for the event.
+	testch := make(chan events.Event, 1)
 	go func() {
 		defer close(testch)
 		for evt := range ch {

--- a/tm2/pkg/bft/consensus/state_test.go
+++ b/tm2/pkg/bft/consensus/state_test.go
@@ -3,6 +3,8 @@ package consensus
 import (
 	"bytes"
 	"fmt"
+	"reflect"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1779,6 +1781,11 @@ func TestStateOutputVoteStats(t *testing.T) {
 	}
 }
 
+var eventid uint32
+
 func subscribe(evsw events.EventSwitch, protoevent events.Event) <-chan events.Event {
-	return events.SubscribeToEvent(evsw, testSubscriber, protoevent)
+	name := reflect.ValueOf(protoevent).Type().Name()
+	id := atomic.AddUint32(&eventid, 1)
+	listenerID := fmt.Sprintf("%s-%s-%d", testSubscriber, name, id)
+	return events.SubscribeToEvent(evsw, listenerID, protoevent)
 }

--- a/tm2/pkg/bft/consensus/state_test.go
+++ b/tm2/pkg/bft/consensus/state_test.go
@@ -1785,7 +1785,12 @@ func subscribe(evsw events.EventSwitch, protoevent events.Event) <-chan events.E
 	listenerID := fmt.Sprintf("%s-%s", testSubscriber, name)
 	ch := events.SubscribeToEvent(evsw, listenerID, protoevent)
 
-	testch := make(chan events.Event, 16)
+	// Similar to the change in common_test.go, this modification introduces
+	// a buffered channel and a separate goroutine for event consumption.
+	// This approach ensures that events are consumed asynchronously,
+	// thereby avoiding the deadlock situation described in the GitHub issue
+	// where the eventSwitch.FireEvent method was blocked.
+	testch := make(chan events.Event, 1)
 	go func() {
 		defer close(testch)
 		for evt := range ch {


### PR DESCRIPTION
test 1 sized channel for state test

<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
